### PR TITLE
feat(getVitestConfig): pass custom nuxt instance and config to `getVitestConfig`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,17 +54,17 @@
   ],
   "dependencies": {
     "@nuxt/kit": "^3.0.0",
+    "@nuxt/schema": "3.0.0",
     "@vue/test-utils": "^2.2.6",
+    "estree-walker": "^3.0.1",
     "h3": "^1.0.2",
     "happy-dom": "^8.1.0",
-    "ofetch": "^1.0.0",
     "magic-string": "^0.27.0",
-    "estree-walker": "^3.0.1",
+    "ofetch": "^1.0.0",
     "unenv": "^1.0.0"
   },
   "devDependencies": {
     "@nuxt/eslint-config": "latest",
-    "@nuxt/schema": "3.0.0",
     "@release-it/conventional-changelog": "latest",
     "@vitest/coverage-c8": "latest",
     "conventional-changelog-conventionalcommits": "latest",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   ],
   "dependencies": {
     "@nuxt/kit": "^3.0.0",
-    "@nuxt/schema": "3.0.0",
     "@vue/test-utils": "^2.2.6",
     "estree-walker": "^3.0.1",
     "h3": "^1.0.2",
@@ -70,6 +69,7 @@
   },
   "devDependencies": {
     "@nuxt/eslint-config": "latest",
+    "@nuxt/schema": "3.0.0",
     "@release-it/conventional-changelog": "latest",
     "@vitest/coverage-c8": "latest",
     "conventional-changelog-conventionalcommits": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,6 @@ importers:
       vue: 3.2.45
     dependencies:
       '@nuxt/kit': 3.0.0
-      '@nuxt/schema': 3.0.0
       '@vue/test-utils': 2.2.6_vue@3.2.45
       estree-walker: 3.0.1
       h3: 1.0.2
@@ -44,6 +43,7 @@ importers:
       unenv: 1.0.0
     devDependencies:
       '@nuxt/eslint-config': 0.1.1_eslint@8.31.0
+      '@nuxt/schema': 3.0.0
       '@release-it/conventional-changelog': 5.1.1_release-it@15.6.0
       '@vitest/coverage-c8': 0.27.1_happy-dom@8.1.0
       conventional-changelog-conventionalcommits: 5.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ importers:
       vue: 3.2.45
     dependencies:
       '@nuxt/kit': 3.0.0
+      '@nuxt/schema': 3.0.0
       '@vue/test-utils': 2.2.6_vue@3.2.45
       estree-walker: 3.0.1
       h3: 1.0.2
@@ -43,7 +44,6 @@ importers:
       unenv: 1.0.0
     devDependencies:
       '@nuxt/eslint-config': 0.1.1_eslint@8.31.0
-      '@nuxt/schema': 3.0.0
       '@release-it/conventional-changelog': 5.1.1_release-it@15.6.0
       '@vitest/coverage-c8': 0.27.1_happy-dom@8.1.0
       conventional-changelog-conventionalcommits: 5.0.0

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,8 +4,8 @@ import { InlineConfig, mergeConfig, defineConfig } from 'vite'
 import autoImportMock from './modules/auto-import-mock'
 
 export interface GetVitestConfigOptions {
-  nuxt: Nuxt,
-  viteConfig: InlineConfig,
+  nuxt: Nuxt
+  viteConfig: InlineConfig
 }
 
 // https://github.com/nuxt/framework/issues/6496
@@ -38,11 +38,10 @@ async function getNuxtAndViteConfig(rootDir = process.cwd()) {
   }).finally(() => nuxt.close())
 }
 
-export async function getVitestConfig(options?: GetVitestConfigOptions): Promise<
-  InlineConfig & { test: VitestConfig }
-> {
-  if (!options)
-    options = await getNuxtAndViteConfig()
+export async function getVitestConfig(
+  options?: GetVitestConfigOptions
+): Promise<InlineConfig & { test: VitestConfig }> {
+  if (!options) options = await getNuxtAndViteConfig()
 
   return {
     ...options.viteConfig,
@@ -56,13 +55,15 @@ export async function getVitestConfig(options?: GetVitestConfigOptions): Promise
           // additional deps
           'vue',
           'vitest-environment-nuxt',
-          ...options.nuxt.options.build.transpile.filter(r => typeof r === 'string' || r instanceof RegExp) as Array<string | RegExp>,
+          ...(options.nuxt.options.build.transpile.filter(
+            r => typeof r === 'string' || r instanceof RegExp
+          ) as Array<string | RegExp>),
         ],
       },
     },
   }
 }
-  
+
 export async function defineConfigWithNuxtEnv(config: InlineConfig = {}) {
   return defineConfig(async () => {
     return mergeConfig(await getVitestConfig(), config)

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import type { InlineConfig as VitestConfig } from 'vitest'
 import { InlineConfig, mergeConfig, defineConfig } from 'vite'
 import autoImportMock from './modules/auto-import-mock'
 
-export interface GetVitestConfigOptions {
+interface GetVitestConfigOptions {
   nuxt: Nuxt
   viteConfig: InlineConfig
 }


### PR DESCRIPTION
So we could use it programically and feed the existing nuxt instance instead of creating a new one.