### PR TITLE
fix: wait a tick for `mountSuspended`

### DIFF
--- a/src/runtime/mount.ts
+++ b/src/runtime/mount.ts
@@ -1,5 +1,5 @@
 import { mount, VueWrapper } from '@vue/test-utils'
-import { h, DefineComponent, Suspense } from 'vue'
+import { h, DefineComponent, Suspense, nextTick } from 'vue'
 
 import { RouterLink } from './components/RouterLink'
 
@@ -16,7 +16,7 @@ export async function mountSuspended<
         render: () =>
           h(
             Suspense,
-            { onResolve: () => resolve(vm as any) },
+            { onResolve: () => nextTick().then(() => resolve(vm as any)) },
             { default: () => h(component) }
           ),
       },


### PR DESCRIPTION
In some scenarios, `Suspense` seems to be resolved synchronously, causing this error: 

<img width="861" alt="image" src="https://user-images.githubusercontent.com/11247099/212870284-6d25bb3d-a58a-4bba-a09a-4516e6d5a5cd.png">
