### PR TITLE
fix: import explicitly h

### DIFF
--- a/packages/vitest-environment-nuxt/src/runtime/components/RouterLink.ts
+++ b/packages/vitest-environment-nuxt/src/runtime/components/RouterLink.ts
@@ -1,4 +1,4 @@
-import { defineComponent, useRouter } from '#imports'
+import { defineComponent, useRouter, h } from '#imports'
 
 export const RouterLink = defineComponent({
   functional: true,


### PR DESCRIPTION
Trying to fix an error I've got when using `mountSuspended` with a component that had a `NuxtLink`:

```
ReferenceError: h is not defined
```

<img width="987" alt="image" src="https://user-images.githubusercontent.com/6775220/213886635-a1d7e02f-8de1-4a26-b9bc-c091487c98f9.png">

Related: https://github.com/danielroe/vitest-environment-nuxt/pull/24

<details>
<summary>ℹ️ More info ⬇️</summary>

The problem is that when the library gets compiled, the `h` gets renamed:

<img width="309" alt="Screenshot 2023-01-21 at 22 47 22" src="https://user-images.githubusercontent.com/6775220/213888200-1153b14c-ce53-492c-ad0d-6fea73b0e299.png">

It's correctly used in the other module that consumes it:

<img width="529" alt="Screenshot 2023-01-21 at 22 48 42" src="https://user-images.githubusercontent.com/6775220/213888236-c7d2d227-a158-4487-b706-7447db2489ad.png">

But not in the `RouterLink` component:

<img width="221" alt="image" src="https://user-images.githubusercontent.com/6775220/213888120-276c1f61-06b9-42f6-b9c8-4e8dadc8fe1f.png">

(all screenshots are in the same file, `/dist/utils.mjs`.)
</details>

